### PR TITLE
Some .png files cannot be progressively loaded on some versions of Android

### DIFF
--- a/ns-image-cache.android.ts
+++ b/ns-image-cache.android.ts
@@ -234,10 +234,16 @@ function setSource(image, value) {
                 fileName = value;
             }
 
-            let request = com.facebook.imagepipeline.request.ImageRequestBuilder
-                .newBuilderWithSource(android.net.Uri.parse(fileName))
-                .setProgressiveRenderingEnabled(true)
-                .build();
+            let request, startRequest = com.facebook.imagepipeline.request.ImageRequestBuilder
+                .newBuilderWithSource(android.net.Uri.parse(fileName));
+
+            if (fileName.indexOf(".png") < 0) {
+                request = startRequest
+                    .setProgressiveRenderingEnabled(true)
+                    .build();
+            } else {
+                request = startRequest.build();
+            }
 
             let controllerListener = new ProxyBaseControllerListener();
             controllerListener.setMyNSCachedImage(image);
@@ -252,7 +258,7 @@ function setSource(image, value) {
 
             image.android.setController(controller);
             image.requestLayout();
-            
+
         } else {
             throw new Error("Path \"" + "\" is not a valid file or resource.");
         }


### PR DESCRIPTION
When this value is enabled it will cause the error message "java.lang.RuntimeException: Failed to pin Bitmap".  Retrying the download will still not solve the issue, as the issue occurs actually during the decoding.  The only way to make it work is to disable progressive loading on png files.  So added code to detect if the url contains ".png" if so, it will use the safer path.